### PR TITLE
Fine tuning state and adding effect

### DIFF
--- a/example/src/commonMain/kotlin/dev/klitsie/statemachine/App.kt
+++ b/example/src/commonMain/kotlin/dev/klitsie/statemachine/App.kt
@@ -11,7 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
-import dev.klitsie.statemachine.nested.ExampleEvent
+import dev.klitsie.statemachine.nested.NestedExampleEffect
+import dev.klitsie.statemachine.nested.NestedExampleEvent
 import dev.klitsie.statemachine.nested.NestedExampleState
 import dev.klitsie.statemachine.nested.NestedExampleViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -20,14 +21,21 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 @Composable
 fun App(onClose: () -> Unit = {}) {
 	MaterialTheme {
-
 		val viewModel = viewModel { NestedExampleViewModel() }
 		val state by viewModel.stateMachine.collectAsStateWithLifecycle()
 
+		LaunchedEffect(viewModel.stateMachine.effect) {
+			viewModel.stateMachine.effect.collect { effect ->
+				when (effect) {
+					NestedExampleEffect.Close -> onClose()
+				}
+			}
+		}
+
 		when (val state = state) {
 			NestedExampleState.Pending -> Button(onClick = {
-				viewModel.stateMachine.onEvent(
-					ExampleEvent.StartLoading("1")
+				viewModel.stateMachine.send(
+					NestedExampleEvent.StartLoading("1")
 				)
 			}) {
 				Text("Start loading!")
@@ -38,19 +46,19 @@ fun App(onClose: () -> Unit = {}) {
 			is NestedExampleState.InputName -> Column {
 				TextField(
 					value = state.username,
-					onValueChange = { viewModel.stateMachine.onEvent(ExampleEvent.UpdateName(it)) })
+					onValueChange = { viewModel.stateMachine.send(NestedExampleEvent.UpdateName(it)) })
 			}
 
 			is NestedExampleState.LoadingFailed.Retryable -> Column {
 				Text("Oh no")
 				Spacer(modifier = Modifier.height(16.dp))
 				Button(onClick = {
-					viewModel.stateMachine.onEvent(ExampleEvent.Retry)
+					viewModel.stateMachine.send(NestedExampleEvent.Retry)
 				}) {
 					Text("Retry")
 				}
 				Button(onClick = {
-					viewModel.stateMachine.onEvent(ExampleEvent.Close)
+					viewModel.stateMachine.send(NestedExampleEvent.Close)
 				}) {
 					Text("Close")
 				}
@@ -61,7 +69,7 @@ fun App(onClose: () -> Unit = {}) {
 				Text("Oh no, you are an idiot")
 				Spacer(modifier = Modifier.height(16.dp))
 				Button(onClick = {
-					viewModel.stateMachine.onEvent(ExampleEvent.Close)
+					viewModel.stateMachine.send(NestedExampleEvent.Close)
 				}) {
 					Text("Close")
 				}
@@ -72,15 +80,11 @@ fun App(onClose: () -> Unit = {}) {
 				Text("Oh no, you are locked out!")
 				Spacer(modifier = Modifier.height(16.dp))
 				Button(onClick = {
-					viewModel.stateMachine.onEvent(ExampleEvent.Close)
+					viewModel.stateMachine.send(NestedExampleEvent.Close)
 				}) {
 					Text("Close")
 				}
 
-			}
-
-			NestedExampleState.CloseScreen -> LaunchedEffect(Unit) {
-				onClose()
 			}
 		}
 	}

--- a/example/src/commonMain/kotlin/dev/klitsie/statemachine/form/FormViewModel.kt
+++ b/example/src/commonMain/kotlin/dev/klitsie/statemachine/form/FormViewModel.kt
@@ -14,7 +14,7 @@ class FormViewModel(
 	private val saveFormDataUseCase: SaveFormDataUseCase,
 ) : ViewModel() {
 
-	private val formStateMachine = stateMachine<FormState, FormEvent>(
+	private val formStateMachine = stateMachine<FormState, Nothing, FormEvent>(
 		scope = viewModelScope,
 		initialState = FormState.LoadingFormData(simulateLoadingFailure = true),
 	) {
@@ -83,7 +83,7 @@ class FormViewModel(
 		state<FormState.Success>()
 	}
 
-	val viewState = formStateMachine.state.map { state ->
+	val viewState = formStateMachine.map { state ->
 		when (state) {
 			is FormState.LoadingFormData -> FormViewState.Loading
 			is FormState.FormLoadingFailure -> FormViewState.Failure
@@ -102,7 +102,7 @@ class FormViewModel(
 	)
 
 	fun onEvent(formEvent: FormEvent) {
-		formStateMachine.onEvent(formEvent)
+		formStateMachine.send(formEvent)
 	}
 
 }

--- a/example/src/commonMain/kotlin/dev/klitsie/statemachine/nested/NestedExampleState.kt
+++ b/example/src/commonMain/kotlin/dev/klitsie/statemachine/nested/NestedExampleState.kt
@@ -14,8 +14,6 @@ sealed interface NestedExampleState {
 
 	}
 
-	data object CloseScreen : NestedExampleState
-
 	sealed interface LoadingFailed : NestedExampleState {
 		data object UserIsAnIdiot : LoadingFailed
 		data object UserLockedOut : LoadingFailed
@@ -24,14 +22,20 @@ sealed interface NestedExampleState {
 
 }
 
-sealed interface ExampleEvent {
+sealed interface NestedExampleEffect {
 
-	data class StartLoading(val id: String) : ExampleEvent
-	data class LoadingResult(val result: Result<String>) : ExampleEvent
-	data class UpdateName(val newValue: String) : ExampleEvent
+	data object Close : NestedExampleEffect
 
-	data object Retry : ExampleEvent
-	data object Reset : ExampleEvent
-	data object Close : ExampleEvent
+}
+
+sealed interface NestedExampleEvent {
+
+	data class StartLoading(val id: String) : NestedExampleEvent
+	data class LoadingResult(val result: Result<String>) : NestedExampleEvent
+	data class UpdateName(val newValue: String) : NestedExampleEvent
+
+	data object Retry : NestedExampleEvent
+	data object Reset : NestedExampleEvent
+	data object Close : NestedExampleEvent
 
 }

--- a/example/src/jvmMain/kotlin/dev/klitsie/statemachine/main.kt
+++ b/example/src/jvmMain/kotlin/dev/klitsie/statemachine/main.kt
@@ -8,6 +8,6 @@ fun main() = application {
         onCloseRequest = ::exitApplication,
         title = "StateMachine",
     ) {
-        App(onClose = {})
+        App(onClose = { println("onClose!") })
     }
 }

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/EffectHandler.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/EffectHandler.kt
@@ -1,0 +1,7 @@
+package dev.klitsie.statemachine
+
+interface EffectHandler<out State : Any, Effect : Any> {
+
+	fun trigger(effect: Effect): State
+
+}

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/SideEffectBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/SideEffectBuilder.kt
@@ -5,7 +5,7 @@ interface SideEffectBuilder<State : Any, CurrentState : State, Event : Any> {
 
 	fun sideEffect(
 		key: (CurrentState) -> Any = { it },
-		effect: suspend StateMachine<State, Event>.(CurrentState) -> Unit,
+		effect: suspend StateMachine<State, *, Event>.(CurrentState) -> Unit,
 	)
 
 	fun buildSideEffects(): List<SideEffect<State, CurrentState, Event>>
@@ -19,7 +19,7 @@ internal class DefaultSideEffectBuilder<State : Any, CurrentState : State, Event
 
 	override fun sideEffect(
 		key: (CurrentState) -> Any,
-		effect: suspend StateMachine<State, Event>.(CurrentState) -> Unit,
+		effect: suspend StateMachine<State, *, Event>.(CurrentState) -> Unit,
 	) {
 		sideEffects += SideEffect(key, effect)
 	}
@@ -30,5 +30,5 @@ internal class DefaultSideEffectBuilder<State : Any, CurrentState : State, Event
 
 data class SideEffect<State : Any, in CurrentState : State, out Event : Any>(
 	val key: (CurrentState) -> Any,
-	val effect: suspend StateMachine<State, Event>.(CurrentState) -> Unit,
+	val effect: suspend StateMachine<State, *, Event>.(CurrentState) -> Unit,
 )

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/StateBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/StateBuilder.kt
@@ -2,28 +2,28 @@ package dev.klitsie.statemachine
 
 import kotlin.reflect.KClass
 
-data class StateDefinition<State : Any, CurrentState : State, Event : Any>(
+data class StateDefinition<State : Any, CurrentState : State, Effect : Any, Event : Any>(
 	val clazz: KClass<out State>,
 	val parent: KClass<out State>?,
 	val sideEffects: List<SideEffect<State, CurrentState, Event>>,
-	val transitions: Map<KClass<out Event>, StateTransition<State, CurrentState, Event>>,
+	val transitions: Map<KClass<out Event>, StateTransition<State, CurrentState, Effect, Event>>,
 )
 
 @StateDsl
-class StateBuilder<State : Any, CurrentState : State, Event : Any>(
+class StateBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any>(
 	private val clazz: KClass<CurrentState>,
 	private val parent: KClass<out State>,
 ) :
 	SideEffectBuilder<State, CurrentState, Event> by DefaultSideEffectBuilder(),
-	TransitionBuilder<State, CurrentState, Event> by DefaultTransitionBuilder() {
+	TransitionBuilder<State, CurrentState, Effect, Event> by DefaultTransitionBuilder() {
 
 	inline fun <reified E : Event> onEvent(
-		noinline transition: (CurrentState, E) -> State,
+		noinline transition: EffectHandler<CurrentState, Effect>.(CurrentState, E) -> State,
 	) {
 		onEvent(E::class, transition)
 	}
 
-	fun build(): StateDefinition<State, CurrentState, Event> {
+	fun build(): StateDefinition<State, CurrentState, Effect, Event> {
 		return StateDefinition(
 			clazz = clazz,
 			parent = parent,

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/StateMachineBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/StateMachineBuilder.kt
@@ -4,12 +4,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlin.reflect.KClass
 
-inline fun <reified State : Any, Event : Any> stateMachine(
+inline fun <reified State : Any, Effect : Any, Event : Any> stateMachine(
 	scope: CoroutineScope,
 	initialState: State,
 	started: SharingStarted = SharingStarted.WhileSubscribed(5000),
-	noinline builder: StateMachineBuilder<State, State, Event>.() -> Unit,
-): StateMachine<State, Event> = stateMachine(
+	noinline builder: StateMachineBuilder<State, State, Effect, Event>.() -> Unit,
+): StateMachine<State, Effect, Event> = stateMachine(
 	baseType = State::class,
 	scope = scope,
 	initialState = initialState,
@@ -17,14 +17,14 @@ inline fun <reified State : Any, Event : Any> stateMachine(
 	builder = builder,
 )
 
-fun <State : Any, Event : Any> stateMachine(
+fun <State : Any, Effect : Any, Event : Any> stateMachine(
 	baseType: KClass<State>,
 	scope: CoroutineScope,
 	initialState: State,
 	started: SharingStarted = SharingStarted.WhileSubscribed(5000),
-	builder: StateMachineBuilder<State, State, Event>.() -> Unit,
-): StateMachine<State, Event> {
-	val stateMachineDefinition = StateMachineBuilder<State, State, Event>(baseType, null)
+	builder: StateMachineBuilder<State, State, Effect, Event>.() -> Unit,
+): StateMachine<State, Effect, Event> {
+	val stateMachineDefinition = StateMachineBuilder<State, State, Effect, Event>(baseType, null)
 		.apply(builder)
 		.build()
 
@@ -40,67 +40,67 @@ fun <State : Any, Event : Any> stateMachine(
 @DslMarker
 annotation class StateDsl
 
-data class StateMachineDefinition<State : Any, CurrentState : State, Event : Any>(
-	val self: StateDefinition<State, CurrentState, Event>,
-	val states: Map<KClass<out CurrentState>, StateDefinition<State, CurrentState, Event>>,
-	val nestedStates: Map<KClass<out CurrentState>, StateMachineDefinition<State, CurrentState, Event>>,
+data class StateMachineDefinition<State : Any, CurrentState : State, Effect : Any, Event : Any>(
+	val self: StateDefinition<State, CurrentState, Effect, Event>,
+	val states: Map<KClass<out CurrentState>, StateDefinition<State, CurrentState, Effect, Event>>,
+	val nestedStates: Map<KClass<out CurrentState>, StateMachineDefinition<State, CurrentState, Effect, Event>>,
 )
 
 @StateDsl
-class StateMachineBuilder<State : Any, CurrentState : State, Event : Any>(
+class StateMachineBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any>(
 	private val clazz: KClass<out State>,
 	private val parent: KClass<out State>?,
 ) :
 	SideEffectBuilder<State, CurrentState, Event> by DefaultSideEffectBuilder(),
-	TransitionBuilder<State, CurrentState, Event> by DefaultTransitionBuilder() {
+	TransitionBuilder<State, CurrentState, Effect, Event> by DefaultTransitionBuilder() {
 
-	var states = emptyMap<KClass<out CurrentState>, StateDefinition<State, CurrentState, Event>>()
+	var states = emptyMap<KClass<out CurrentState>, StateDefinition<State, CurrentState, Effect, Event>>()
 		private set
 
-	var nestedStates = emptyMap<KClass<out CurrentState>, StateMachineDefinition<State, CurrentState, Event>>()
+	var nestedStates = emptyMap<KClass<out CurrentState>, StateMachineDefinition<State, CurrentState, Effect, Event>>()
 		private set
 
 	inline fun <reified E : Event> onEvent(
-		noinline transition: (CurrentState, E) -> State,
+		noinline transition: EffectHandler<CurrentState, Effect>.(CurrentState, E) -> State,
 	) {
 		onEvent(E::class, transition)
 	}
 
 	inline fun <reified S : CurrentState> state(
-		noinline stateBuilder: StateBuilder<State, S, Event>.() -> Unit = {},
+		noinline stateBuilder: StateBuilder<State, S, Effect, Event>.() -> Unit = {},
 	) {
 		state(S::class, stateBuilder)
 	}
 
 	inline fun <reified S : CurrentState> nestedState(
-		noinline nestedStateBuilder: StateMachineBuilder<State, S, Event>.() -> Unit,
+		noinline nestedStateBuilder: StateMachineBuilder<State, S, Effect, Event>.() -> Unit,
 	) {
 		nestedState(S::class, nestedStateBuilder)
 	}
 
 	fun <S : CurrentState> state(
 		stateClass: KClass<S>,
-		stateBuilder: StateBuilder<State, S, Event>.() -> Unit,
+		stateBuilder: StateBuilder<State, S, Effect, Event>.() -> Unit,
 	) {
 		@Suppress("UNCHECKED_CAST")
-		val stateHolder = StateBuilder<State, S, Event>(stateClass, clazz).apply(stateBuilder)
-			.build() as StateDefinition<State, CurrentState, Event>
+		val stateHolder = StateBuilder<State, S, Effect, Event>(stateClass, clazz).apply(stateBuilder)
+			.build() as StateDefinition<State, CurrentState, Effect, Event>
 		states = states
 			.plus(stateClass to stateHolder)
 	}
 
 	fun <S : CurrentState> nestedState(
 		stateClass: KClass<out S>,
-		stateBuilder: StateMachineBuilder<State, S, Event>.() -> Unit,
+		stateBuilder: StateMachineBuilder<State, S, Effect, Event>.() -> Unit,
 	) {
 		@Suppress("UNCHECKED_CAST")
-		val nestedState = StateMachineBuilder<State, S, Event>(stateClass, clazz)
+		val nestedState = StateMachineBuilder<State, S, Effect, Event>(stateClass, clazz)
 			.apply(stateBuilder)
-			.build() as StateMachineDefinition<State, CurrentState, Event>
+			.build() as StateMachineDefinition<State, CurrentState, Effect, Event>
 		this.nestedStates += nestedState.nestedStates.plus(stateClass to nestedState)
 	}
 
-	fun build(): StateMachineDefinition<State, CurrentState, Event> {
+	fun build(): StateMachineDefinition<State, CurrentState, Effect, Event> {
 		return StateMachineDefinition(
 			self = StateDefinition(
 				clazz = clazz,

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/TransitionBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/TransitionBuilder.kt
@@ -2,29 +2,33 @@ package dev.klitsie.statemachine
 
 import kotlin.reflect.KClass
 
-data class StateTransition<State : Any, CurrentState : State, Event : Any>(
-	val transition: (CurrentState, Event) -> State,
+data class StateTransition<State : Any, CurrentState : State, Effect : Any, Event : Any>(
+	val transition: EffectHandler<CurrentState, Effect>.(CurrentState, Event) -> State,
 )
 
 @StateDsl
-interface TransitionBuilder<State : Any, CurrentState : State, Event : Any> {
+interface TransitionBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any> {
 
-	fun <E : Event> onEvent(eventClass: KClass<E>, transition: (CurrentState, E) -> State)
-	fun buildTransitions(): Map<KClass<out Event>, StateTransition<State, CurrentState, Event>>
+	fun <E : Event> onEvent(
+		eventClass: KClass<E>,
+		transition: EffectHandler<CurrentState, Effect>.(CurrentState, E) -> State
+	)
+
+	fun buildTransitions(): Map<KClass<out Event>, StateTransition<State, CurrentState, Effect, Event>>
 
 }
 
-internal class DefaultTransitionBuilder<State : Any, CurrentState : State, Event : Any> :
-	TransitionBuilder<State, CurrentState, Event> {
+internal class DefaultTransitionBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any> :
+	TransitionBuilder<State, CurrentState, Effect, Event> {
 
-	private var transitions = mapOf<KClass<out Event>, StateTransition<State, CurrentState, Event>>()
+	private var transitions = mapOf<KClass<out Event>, StateTransition<State, CurrentState, Effect, Event>>()
 
 	override fun <E : Event> onEvent(
 		eventClass: KClass<E>,
-		transition: (CurrentState, E) -> State,
+		transition: EffectHandler<CurrentState, Effect>.(CurrentState, E) -> State,
 	) {
 		@Suppress("UNCHECKED_CAST")
-		val stateTransition = StateTransition(transition) as StateTransition<State, CurrentState, Event>
+		val stateTransition = StateTransition(transition) as StateTransition<State, CurrentState, Effect, Event>
 		transitions = transitions
 			.plus(eventClass to stateTransition)
 	}


### PR DESCRIPTION
Instead of onEvent(), use send() to send events
Added new Effect. Effects can be useful to trigger an effect without having to switch states (like GoBack). Effects live in a channel and use a trigger() method, accessible in the onEvent<> {} blocks.