### PR TITLE
Added safer way to consume effects, now we only expose a consumeEffec…

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -31,11 +31,9 @@ kotlin {
             commonWebpackConfig {
                 outputFileName = "composeApp.js"
                 devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
-                    static = (static ?: mutableListOf()).apply {
-                        // Serve sources to debug inside browser
-                        add(rootDirPath)
-                        add(projectDirPath)
-                    }
+                    // Serve sources to debug inside the browser
+                    static(rootDirPath)
+                    static(projectDirPath)
                 }
             }
         }
@@ -69,11 +67,11 @@ kotlin {
 }
 
 android {
-    namespace = "com.klitsie.statemachine"
+    namespace = "dev.klitsie.statemachine.example"
     compileSdk = libs.versions.android.compileSdk.get().toInt()
 
     defaultConfig {
-        applicationId = "com.klitsie.statemachine"
+        applicationId = "dev.klitsie.statemachine.example"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
         versionCode = 1
@@ -101,11 +99,11 @@ dependencies {
 
 compose.desktop {
     application {
-        mainClass = "com.klitsie.statemachine.MainKt"
+        mainClass = "dev.klitsie.statemachine.MainKt"
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
-            packageName = "com.klitsie.statemachine"
+            packageName = "dev.klitsie.statemachine"
             packageVersion = "1.0.0"
         }
     }

--- a/library/build.gradle.kts
+++ b/library/build.gradle.kts
@@ -13,11 +13,11 @@ plugins {
 }
 
 group = "dev.klitsie.statemachine"
-version = "0.2.0"
+version = "0.3.0"
 
 kotlin {
 	androidLibrary {
-		namespace = "com.klitsie.statemachine"
+		namespace = "dev.klitsie.statemachine"
 		compileSdk = libs.versions.android.compileSdk.get().toInt()
 		minSdk = libs.versions.android.minSdk.get().toInt()
 

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/EffectHandler.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/EffectHandler.kt
@@ -1,7 +1,14 @@
 package dev.klitsie.statemachine
 
+/**
+ * Scope for handling effects within a state transition.
+ */
+@StateDsl
 interface EffectHandler<out State : Any, Effect : Any> {
 
+	/**
+	 * Triggers an [effect] and returns the current [State].
+	 */
 	fun trigger(effect: Effect): State
 
 }

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/SideEffectBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/SideEffectBuilder.kt
@@ -1,13 +1,26 @@
 package dev.klitsie.statemachine
 
+/**
+ * Builder for defining side effects that should run when a state is entered.
+ */
 @StateDsl
 interface SideEffectBuilder<State : Any, CurrentState : State, Event : Any> {
 
+	/**
+	 * Defines a side effect to run when this state is entered.
+	 *
+	 * @param key A key to uniquely identify this side effect. If the state changes but the key remains the same,
+	 * the side effect will not be restarted.
+	 * @param effect The side effect to run. It's executed in a [StateMachine] scope.
+	 */
 	fun sideEffect(
 		key: (CurrentState) -> Any = { it },
 		effect: suspend StateMachine<State, *, Event>.(CurrentState) -> Unit,
 	)
 
+	/**
+	 * Builds the list of defined side effects.
+	 */
 	fun buildSideEffects(): List<SideEffect<State, CurrentState, Event>>
 
 }
@@ -28,6 +41,9 @@ internal class DefaultSideEffectBuilder<State : Any, CurrentState : State, Event
 
 }
 
+/**
+ * Represents a side effect to be executed in a state.
+ */
 data class SideEffect<State : Any, in CurrentState : State, out Event : Any>(
 	val key: (CurrentState) -> Any,
 	val effect: suspend StateMachine<State, *, Event>.(CurrentState) -> Unit,

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/StateBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/StateBuilder.kt
@@ -2,6 +2,9 @@ package dev.klitsie.statemachine
 
 import kotlin.reflect.KClass
 
+/**
+ * Definition of a single state, including its transitions and side effects.
+ */
 data class StateDefinition<State : Any, CurrentState : State, Effect : Any, Event : Any>(
 	val clazz: KClass<out State>,
 	val parent: KClass<out State>?,
@@ -9,6 +12,9 @@ data class StateDefinition<State : Any, CurrentState : State, Effect : Any, Even
 	val transitions: Map<KClass<out Event>, StateTransition<State, CurrentState, Effect, Event>>,
 )
 
+/**
+ * Builder for defining a single state.
+ */
 @StateDsl
 class StateBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any>(
 	private val clazz: KClass<CurrentState>,
@@ -17,12 +23,18 @@ class StateBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any>
 	SideEffectBuilder<State, CurrentState, Event> by DefaultSideEffectBuilder(),
 	TransitionBuilder<State, CurrentState, Effect, Event> by DefaultTransitionBuilder() {
 
+	/**
+	 * Defines a transition for when an event of type [E] is received.
+	 */
 	inline fun <reified E : Event> onEvent(
 		noinline transition: EffectHandler<CurrentState, Effect>.(state: CurrentState, event: E) -> State,
 	) {
 		onEvent(E::class, transition)
 	}
 
+	/**
+	 * Builds the [StateDefinition].
+	 */
 	fun build(): StateDefinition<State, CurrentState, Effect, Event> {
 		return StateDefinition(
 			clazz = clazz,

--- a/library/src/commonMain/kotlin/dev/klitsie/statemachine/TransitionBuilder.kt
+++ b/library/src/commonMain/kotlin/dev/klitsie/statemachine/TransitionBuilder.kt
@@ -2,18 +2,30 @@ package dev.klitsie.statemachine
 
 import kotlin.reflect.KClass
 
+/**
+ * Represents a transition from one state to another triggered by an event.
+ */
 data class StateTransition<State : Any, CurrentState : State, Effect : Any, Event : Any>(
 	val transition: EffectHandler<CurrentState, Effect>.(CurrentState, Event) -> State,
 )
 
+/**
+ * Builder for defining transitions between states.
+ */
 @StateDsl
 interface TransitionBuilder<State : Any, CurrentState : State, Effect : Any, Event : Any> {
 
+	/**
+	 * Defines a transition for the given [eventClass].
+	 */
 	fun <E : Event> onEvent(
 		eventClass: KClass<E>,
-		transition: EffectHandler<CurrentState, Effect>.(CurrentState, E) -> State
+		transition: EffectHandler<CurrentState, Effect>.(CurrentState, E) -> State,
 	)
 
+	/**
+	 * Builds the map of defined transitions.
+	 */
 	fun buildTransitions(): Map<KClass<out Event>, StateTransition<State, CurrentState, Effect, Event>>
 
 }

--- a/library/src/commonTest/kotlin/dev/klitsie/statemachine/EffectTest.kt
+++ b/library/src/commonTest/kotlin/dev/klitsie/statemachine/EffectTest.kt
@@ -1,0 +1,242 @@
+package dev.klitsie.statemachine
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * A test suite for validating the behavior of a state machine in regard to handling
+ * and consuming side effects across multiple scenarios.
+ *
+ * This class specifically tests the `stateMachine` implementation to ensure that:
+ * - Effects can be triggered and collected correctly, even when triggered in bulk or from
+ *   multiple threads.
+ * - Effects are consumed only once across different coroutine scopes.
+ * - Effects handling can resume properly after cancellation.
+ * - It is possible to trigger effects and update states simultaneously.
+ *
+ * Each test validates specific behavior related to the state machine's effect handling
+ * capabilities by simulating various edge cases and verifying state transitions and effect consumption.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EffectTest {
+
+	@Test
+	fun `Check we can trigger multiple effects and can collect them from from multiple threads`() = runTest {
+		val expectedEffects = List(1000) { TestEffect.Count(it + 1) }
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.MoveForward> { _, _ ->
+					repeat(expectedEffects.size) {
+						trigger(TestEffect.Count(it + 1))
+					}
+					trigger(TestEffect.Close)
+				}
+			}
+		}
+
+		val consumedEventsAndJobs = List(10) { mutableListOf<TestEffect>() }
+			.associateWith { actualEffects ->
+				backgroundScope.launch {
+					withContext(Dispatchers.Default) {
+						machine.consumeEffects { effect ->
+							when (effect) {
+								TestEffect.Close -> cancel()
+								is TestEffect.Count -> actualEffects.add(effect)
+							}
+						}
+					}
+				}
+			}
+
+		// Make sure consuming started before sending event
+		advanceTimeBy(10)
+		machine.send(TestEvent.MoveForward)
+
+		consumedEventsAndJobs.values.joinAll()
+
+		consumedEventsAndJobs.keys.forEach { actualEffects ->
+			assertContentEquals(expectedEffects, actualEffects)
+		}
+
+		assertEquals(
+			TestState.StateA(value = "I am a value"),
+			machine.value,
+		)
+	}
+
+	@Test
+	fun `Check we correctly consume effects once`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.Close> { _, _ ->
+					trigger(TestEffect.Close)
+				}
+			}
+		}
+
+		var effectBeforeCancel: TestEffect? = null
+
+		val job1 = backgroundScope.launch {
+			machine.consumeEffects {
+				effectBeforeCancel = it
+				cancel()
+			}
+		}
+		var effectAfterCancel: TestEffect? = null
+		backgroundScope.launch {
+			advanceUntilIdle()
+			job1.join()
+			advanceTimeBy(1)
+			machine.consumeEffects {
+				effectAfterCancel = it
+			}
+		}
+
+		machine.send(TestEvent.Close)
+		advanceTimeBy(4)
+
+		assertEquals(TestEffect.Close, effectBeforeCancel)
+		assertNull(effectAfterCancel)
+
+		assertEquals(
+			TestState.StateA(value = "I am a value"),
+			machine.value,
+		)
+	}
+
+	@Test
+	fun `Check we can continue consuming effects after cancellation`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.Close> { _, _ ->
+					trigger(TestEffect.Count(1))
+					trigger(TestEffect.Count(2))
+				}
+			}
+		}
+
+		var effectBeforeCancel: TestEffect? = null
+
+		val job1 = backgroundScope.launch {
+			machine.consumeEffects {
+				effectBeforeCancel = it
+				cancel()
+			}
+		}
+		var effectAfterCancel: TestEffect? = null
+		backgroundScope.launch {
+			advanceUntilIdle()
+			job1.join()
+			advanceTimeBy(1)
+			machine.consumeEffects {
+				effectAfterCancel = it
+			}
+		}
+
+		machine.send(TestEvent.Close)
+		advanceTimeBy(4)
+
+		assertEquals(TestEffect.Count(1), effectBeforeCancel)
+		assertEquals(TestEffect.Count(2), effectAfterCancel)
+
+		assertEquals(
+			TestState.StateA(value = "I am a value"),
+			machine.value,
+		)
+	}
+
+	@Test
+	fun `Check we consume effects only 1 time`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.Close> { _, _ ->
+					trigger(TestEffect.Close)
+				}
+			}
+		}
+
+		var effect1: TestEffect? = null
+		var effect2: TestEffect? = null
+
+		backgroundScope.launch {
+			machine.consumeEffects {
+				effect1 = it
+			}
+		}
+
+		machine.send(TestEvent.Close)
+		advanceTimeBy(1)
+
+		backgroundScope.launch {
+			machine.consumeEffects {
+				effect2 = it
+			}
+		}
+		advanceTimeBy(1)
+
+		assertEquals(TestEffect.Close, effect1)
+		assertNull(effect2)
+
+		assertEquals(
+			TestState.StateA(value = "I am a value"),
+			machine.value,
+		)
+	}
+
+	@Test
+	fun `Check we can trigger effects and update state`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.Close> { state, _ ->
+					trigger(TestEffect.Close)
+					TestState.StateB(value = state.value)
+				}
+			}
+		}
+
+		machine.send(TestEvent.Close)
+		advanceUntilIdle()
+
+		var effect: TestEffect? = null
+		backgroundScope.launch {
+			machine.consumeEffects { effect = it }
+		}
+
+		advanceTimeBy(1)
+		assertEquals(TestEffect.Close, effect)
+
+		assertEquals(
+			TestState.StateB(value = "I am a value"),
+			machine.value,
+		)
+	}
+
+
+}

--- a/library/src/commonTest/kotlin/dev/klitsie/statemachine/EventTest.kt
+++ b/library/src/commonTest/kotlin/dev/klitsie/statemachine/EventTest.kt
@@ -1,0 +1,334 @@
+package dev.klitsie.statemachine
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * A test class for verifying the behavior of the state machine that
+ * transitions between different states based on events and optionally
+ * handles side effects during state changes. This test suite evaluates
+ * multiple scenarios to ensure correctness of state transitions, event
+ * handling precedence, and handling of unhandled or deferred events.
+ *
+ * The tested state machine supports the following features:
+ *
+ * - Transitioning between states based on events.
+ * - Handling nested states within the parent states.
+ * - Processing side effects within states.
+ * - Defining precedence between parent and child states.
+ * - Ignoring unhandled events unless explicitly handled.
+ * - Suspending event handling when the state machine is inactive.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventTest {
+
+	@Test
+	fun `Check transitioning to different states`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.NestedState.NestedStateA(nestedValue = state.value)
+				}
+			}
+			nestedState<TestState.NestedState> {
+				state<TestState.NestedState.NestedStateA> {
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
+					}
+				}
+				state<TestState.NestedState.NestedStateB> {
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.StateB(value = state.nestedValue)
+					}
+				}
+			}
+			state<TestState.StateB>()
+		}
+
+		val expected = listOf(
+			TestState.StateA(value = "I am a value"),
+			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
+			TestState.NestedState.NestedStateB(nestedValue = "I am a value"),
+			TestState.StateB(value = "I am a value"),
+		)
+
+		val actual = backgroundScope.async {
+			machine.take(expected.count()).toList()
+		}
+
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+
+		assertContentEquals(expected, actual.await())
+	}
+
+	@Test
+	fun `Check transitioning to different states from side effects`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+		) {
+			state<TestState.StateA> {
+				sideEffect { send(TestEvent.MoveForward) }
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.NestedState.NestedStateA(nestedValue = state.value)
+				}
+			}
+			nestedState<TestState.NestedState> {
+				sideEffect { send(TestEvent.MoveForward) }
+				state<TestState.NestedState.NestedStateA> {
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
+					}
+				}
+				state<TestState.NestedState.NestedStateB> {
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.StateB(value = state.nestedValue)
+					}
+				}
+			}
+			state<TestState.StateB>()
+		}
+
+		val expected = listOf(
+			TestState.StateA(value = "I am a value"),
+			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
+			TestState.NestedState.NestedStateB(nestedValue = "I am a value"),
+			TestState.StateB(value = "I am a value"),
+		)
+
+		val actual = backgroundScope.async {
+			machine.take(expected.count()).toList()
+		}
+
+		assertContentEquals(expected, actual.await())
+	}
+
+	@Test
+	fun `Check children will handle events before parents`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.NestedState.NestedStateA("I am a value"),
+		) {
+			onEvent<TestEvent.MoveForward> { state, _ ->
+				TestState.StateA(
+					value = when (state) {
+						is TestState.StateA -> state.value
+						is TestState.StateB -> state.value
+						is TestState.StateC -> state.value
+						is TestState.NestedState -> state.nestedValue
+					},
+				)
+			}
+			nestedState<TestState.NestedState> {
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.StateB(value = state.nestedValue)
+				}
+				state<TestState.NestedState.NestedStateA> {
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.StateC(value = state.nestedValue)
+					}
+				}
+				state<TestState.NestedState.NestedStateB>()
+			}
+			state<TestState.StateA>()
+			state<TestState.StateB>()
+			state<TestState.StateC>()
+		}
+
+		val expected = listOf(
+			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
+			TestState.StateC(value = "I am a value"),
+		)
+
+		val actual = backgroundScope.async {
+			machine.take(expected.count()).toList()
+		}
+
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+
+		assertContentEquals(expected, actual.await())
+	}
+
+	@Test
+	fun `Check parents will handle events before state machine`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.NestedState.NestedStateA("I am a value"),
+		) {
+			onEvent<TestEvent.MoveForward> { state, _ ->
+				TestState.StateA(
+					value = when (state) {
+						is TestState.StateA -> state.value
+						is TestState.StateB -> state.value
+						is TestState.StateC -> state.value
+						is TestState.NestedState -> state.nestedValue
+					},
+				)
+			}
+			nestedState<TestState.NestedState> {
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.StateB(value = state.nestedValue)
+				}
+				state<TestState.NestedState.NestedStateA>()
+				state<TestState.NestedState.NestedStateB>()
+			}
+			state<TestState.StateA>()
+			state<TestState.StateB>()
+			state<TestState.StateC>()
+		}
+
+		val expected = listOf(
+			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
+			TestState.StateB(value = "I am a value"),
+		)
+
+		val actual = backgroundScope.async {
+			machine.take(expected.count()).toList()
+		}
+
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+
+		assertContentEquals(expected, actual.await())
+	}
+
+	@Test
+	fun `Check parents will handle events if no defined state handles it`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.NestedState.NestedStateA("I am a value"),
+		) {
+			onEvent<TestEvent.MoveForward> { state, _ ->
+				TestState.StateA(
+					value = when (state) {
+						is TestState.StateA -> state.value
+						is TestState.StateB -> state.value
+						is TestState.StateC -> state.value
+						is TestState.NestedState -> state.nestedValue
+					},
+				)
+			}
+			nestedState<TestState.NestedState> {
+				state<TestState.NestedState.NestedStateA>()
+				state<TestState.NestedState.NestedStateB>()
+			}
+			state<TestState.StateA>()
+			state<TestState.StateB>()
+			state<TestState.StateC>()
+		}
+
+		val expected = listOf(
+			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
+			TestState.StateA(value = "I am a value"),
+		)
+
+		val actual = backgroundScope.async {
+			machine.take(expected.count()).toList()
+		}
+
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+
+		assertContentEquals(expected, actual.await())
+	}
+
+	@Test
+	fun `Check we ignore unhandled events`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.NestedState.NestedStateA("I am a value"),
+		) {
+			nestedState<TestState.NestedState> {
+				state<TestState.NestedState.NestedStateA>()
+				state<TestState.NestedState.NestedStateB>()
+			}
+			state<TestState.StateA>()
+			state<TestState.StateB>()
+			state<TestState.StateC>()
+		}
+
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+
+		assertEquals(
+			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
+			machine.value,
+		)
+	}
+
+	@Test
+	fun `Check we suspend events while state machine is inactive`() = runTest {
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.WhileSubscribed(),
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.StateB(value = state.value)
+				}
+			}
+			state<TestState.StateB> {
+				onEvent<TestEvent.Append> { state, event ->
+					state.copy(value = state.value + event.value)
+				}
+			}
+		}
+
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+
+		// Check we didn't change state yet as collection didn't start
+		assertEquals(TestState.StateA("I am a value"), machine.value)
+		val observeJob = backgroundScope.launch { machine.collect() }
+		advanceTimeBy(1.milliseconds)
+
+		// Check we moved state after collection started
+		assertEquals(TestState.StateB("I am a value"), machine.value)
+
+		observeJob.cancel()
+		// Check we keep state
+		advanceTimeBy(1.milliseconds)
+		assertEquals(TestState.StateB("I am a value"), machine.value)
+
+		// Send a bunch of events
+		machine.send(TestEvent.Append("-"))
+		machine.send(TestEvent.Append("-"))
+		machine.send(TestEvent.Append("-"))
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.Append("-"))
+		advanceTimeBy(1.milliseconds)
+
+		// Make sure nothing happened yet
+		assertEquals(TestState.StateB("I am a value"), machine.value)
+
+		// Restart work
+		backgroundScope.launch { machine.collect() }
+		advanceTimeBy(1.milliseconds)
+
+		// Check we kept the events to update after we started to collect
+		assertEquals(TestState.StateB("I am a value----"), machine.value)
+	}
+
+}

--- a/library/src/commonTest/kotlin/dev/klitsie/statemachine/SideEffectTest.kt
+++ b/library/src/commonTest/kotlin/dev/klitsie/statemachine/SideEffectTest.kt
@@ -1,0 +1,217 @@
+package dev.klitsie.statemachine
+
+import kotlinx.coroutines.*
+import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.*
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A test suite for validating the behavior of a state machine with side effects.
+ *
+ * This class contains test cases to ensure:
+ * - Side effects are triggered as expected on state changes.
+ * - Keys are used correctly to prevent duplicate side effect triggers when the state doesn't change meaningfully.
+ * - Side effects are properly canceled when the state machine becomes inactive.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SideEffectTest {
+
+
+	@Test
+	fun `Check all side effects will run on every state change if no key is given`() = runTest {
+		var machineSideEffectCounter = 0
+		var stateASideEffectCounter = 0
+		var nestedSideEffectCounter = 0
+		var nestedStateASideEffectCounter = 0
+		var nestedStateBSideEffectCounter = 0
+
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			sideEffect {
+				machineSideEffectCounter++
+			}
+			state<TestState.StateA> {
+				sideEffect {
+					stateASideEffectCounter++
+				}
+
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.NestedState.NestedStateA(nestedValue = state.value)
+				}
+			}
+			nestedState<TestState.NestedState> {
+				sideEffect {
+					nestedSideEffectCounter++
+				}
+
+				state<TestState.NestedState.NestedStateA> {
+					sideEffect {
+						nestedStateASideEffectCounter++
+					}
+
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
+					}
+				}
+				state<TestState.NestedState.NestedStateB> {
+					sideEffect {
+						nestedStateBSideEffectCounter++
+					}
+				}
+			}
+		}
+
+		val expectedStates = listOf(
+			TestState.StateA("I am a value"),
+			TestState.NestedState.NestedStateA("I am a value"),
+			TestState.NestedState.NestedStateB("I am a value"),
+		)
+
+		val actualStates = backgroundScope.async { machine.take(expectedStates.count()).toList() }
+
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+
+		assertContentEquals(expectedStates, actualStates.await())
+		assertEquals(3, machineSideEffectCounter)
+		assertEquals(1, stateASideEffectCounter)
+		assertEquals(2, nestedSideEffectCounter)
+		assertEquals(1, nestedStateASideEffectCounter)
+		assertEquals(1, nestedStateBSideEffectCounter)
+	}
+
+	@Test
+	fun `Check side effects will not run multiple times if key doesn't change`() = runTest {
+		var machineSideEffectCounter = 0
+		var stateASideEffectCounter = 0
+		var nestedSideEffectCounter = 0
+		var nestedStateASideEffectCounter = 0
+		var nestedStateBSideEffectCounter = 0
+
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.Eagerly,
+		) {
+			sideEffect(
+				key = { state ->
+					// Do a stupid comparison to just show we can calculate the keys
+					when (state) {
+						is TestState.NestedState -> state.nestedValue
+						is TestState.StateA -> state.value
+						is TestState.StateB -> state.value
+						is TestState.StateC -> state.value
+					}
+				},
+			) {
+				machineSideEffectCounter++
+			}
+			state<TestState.StateA> {
+				sideEffect(key = {}) { // Can simply use Unit
+					stateASideEffectCounter++
+				}
+
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.NestedState.NestedStateA(nestedValue = state.value)
+				}
+			}
+			nestedState<TestState.NestedState> {
+				sideEffect(key = {}) { // Can simply use Unit to never run again
+					nestedSideEffectCounter++
+				}
+
+				state<TestState.NestedState.NestedStateA> {
+					sideEffect(key = {}) { // Can simply use Unit
+						nestedStateASideEffectCounter++
+					}
+
+					onEvent<TestEvent.MoveForward> { state, _ ->
+						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
+					}
+				}
+				state<TestState.NestedState.NestedStateB> {
+					sideEffect(key = { state -> state.nestedValue }) {
+						nestedStateBSideEffectCounter++
+					}
+
+					onEvent<TestEvent.Append> { state, event ->
+						state.copy(nestedValue = state.nestedValue + event.value)
+					}
+				}
+			}
+		}
+
+		val expectedStates = listOf(
+			TestState.StateA("I am a value"),
+			TestState.NestedState.NestedStateA("I am a value"),
+			TestState.NestedState.NestedStateB("I am a value"),
+			TestState.NestedState.NestedStateB("I am a value!!!"),
+		)
+
+		val actualStates = backgroundScope.async { machine.take(expectedStates.count()).toList() }
+
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.MoveForward)
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.Append(""))
+		advanceTimeBy(1.milliseconds)
+		machine.send(TestEvent.Append("!!!"))
+		advanceTimeBy(1.milliseconds)
+
+		assertContentEquals(expectedStates, actualStates.await())
+		assertEquals(2, machineSideEffectCounter)
+		assertEquals(1, stateASideEffectCounter)
+		assertEquals(1, nestedSideEffectCounter)
+		assertEquals(1, nestedStateASideEffectCounter)
+		assertEquals(2, nestedStateBSideEffectCounter)
+	}
+
+	@Test
+	fun `Check side effects are cancelled when machine gets inactive after default 5 seconds`() = runTest {
+		var sideEffectJob: Job? = null
+
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.WhileSubscribed(5.seconds),
+		) {
+			state<TestState.StateA> {
+				sideEffect {
+					coroutineScope {
+						sideEffectJob = launch { delay(Long.MAX_VALUE) }
+					}
+				}
+			}
+		}
+
+		advanceUntilIdle()
+		assertNull(sideEffectJob)
+
+		val observeJob = backgroundScope.launch { machine.collect() }
+		advanceTimeBy(1.milliseconds)
+
+		assertTrue { assertNotNull(sideEffectJob).isActive }
+
+		observeJob.cancel()
+		advanceTimeBy(4.seconds)
+
+		// Job should still be active
+		assertTrue { assertNotNull(sideEffectJob).isActive }
+
+		advanceTimeBy(2.seconds)
+
+		// Now the job should be cancelled
+		assertTrue { assertNotNull(sideEffectJob).isCancelled }
+	}
+
+}

--- a/library/src/commonTest/kotlin/dev/klitsie/statemachine/StateMachineTest.kt
+++ b/library/src/commonTest/kotlin/dev/klitsie/statemachine/StateMachineTest.kt
@@ -1,449 +1,40 @@
 package dev.klitsie.statemachine
 
-import kotlinx.coroutines.*
-import kotlinx.coroutines.flow.*
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceTimeBy
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
 import kotlin.time.Duration.Companion.milliseconds
-import kotlin.time.Duration.Companion.seconds
 
+/**
+ * Unit tests for verifying the functionality of a state machine implementation.
+ *
+ * This test class ensures that various behaviors of the state machine, such as
+ * state transitions, side effects, and event handling, function as expected.
+ * The state machine under test operates with the [TestState], [TestEffect], and
+ * [TestEvent] sealed interfaces as its core logic components.
+ *
+ * The tests use structured concurrency to simulate state transitions and
+ * perform assertions on the expected outcomes.
+ *
+ * Test cases included:
+ * 1. Verifying no actions occur if a new state is the same as the previous state.
+ * 2. Confirming that the last declared definition of a state takes precedence over earlier definitions.
+ * 3. Ensuring the state machine can start with an undefined state configuration.
+ * 4. Checking transitions to undefined states and confirming behavior when events are sent in these states.
+ * 5. Verifying that the state machine resumes from its last state and side effects restart upon restarting.
+ *
+ * The tests make use of coroutines and time manipulation for simulating asynchronous state transitions
+ * and timing behavior.
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class StateMachineTest {
-
-	@Test
-	fun `Check transitioning to different states`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-		) {
-			state<TestState.StateA> {
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.NestedState.NestedStateA(nestedValue = state.value)
-				}
-			}
-			nestedState<TestState.NestedState> {
-				state<TestState.NestedState.NestedStateA> {
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
-					}
-				}
-				state<TestState.NestedState.NestedStateB> {
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.StateB(value = state.nestedValue)
-					}
-				}
-			}
-			state<TestState.StateB>()
-		}
-
-		val expected = listOf(
-			TestState.StateA(value = "I am a value"),
-			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
-			TestState.NestedState.NestedStateB(nestedValue = "I am a value"),
-			TestState.StateB(value = "I am a value"),
-		)
-
-		val actual = backgroundScope.async {
-			machine.take(expected.count()).toList()
-		}
-
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-
-		assertContentEquals(expected, actual.await())
-	}
-
-	@Test
-	fun `Check transitioning to different states from side effects`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-		) {
-			state<TestState.StateA> {
-				sideEffect { send(TestEvent.MoveForward) }
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.NestedState.NestedStateA(nestedValue = state.value)
-				}
-			}
-			nestedState<TestState.NestedState> {
-				sideEffect { send(TestEvent.MoveForward) }
-				state<TestState.NestedState.NestedStateA> {
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
-					}
-				}
-				state<TestState.NestedState.NestedStateB> {
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.StateB(value = state.nestedValue)
-					}
-				}
-			}
-			state<TestState.StateB>()
-		}
-
-		val expected = listOf(
-			TestState.StateA(value = "I am a value"),
-			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
-			TestState.NestedState.NestedStateB(nestedValue = "I am a value"),
-			TestState.StateB(value = "I am a value"),
-		)
-
-		val actual = backgroundScope.async {
-			machine.take(expected.count()).toList()
-		}
-
-		assertContentEquals(expected, actual.await())
-	}
-
-	@Test
-	fun `Check children will handle events before parents`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.NestedState.NestedStateA("I am a value"),
-		) {
-			onEvent<TestEvent.MoveForward> { state, _ ->
-				TestState.StateA(
-					value = when (state) {
-						is TestState.StateA -> state.value
-						is TestState.StateB -> state.value
-						is TestState.StateC -> state.value
-						is TestState.NestedState -> state.nestedValue
-					},
-				)
-			}
-			nestedState<TestState.NestedState> {
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.StateB(value = state.nestedValue)
-				}
-				state<TestState.NestedState.NestedStateA> {
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.StateC(value = state.nestedValue)
-					}
-				}
-				state<TestState.NestedState.NestedStateB>()
-			}
-			state<TestState.StateA>()
-			state<TestState.StateB>()
-			state<TestState.StateC>()
-		}
-
-		val expected = listOf(
-			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
-			TestState.StateC(value = "I am a value"),
-		)
-
-		val actual = backgroundScope.async {
-			machine.take(expected.count()).toList()
-		}
-
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-
-		assertContentEquals(expected, actual.await())
-	}
-
-	@Test
-	fun `Check parents will handle events before state machine`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.NestedState.NestedStateA("I am a value"),
-		) {
-			onEvent<TestEvent.MoveForward> { state, _ ->
-				TestState.StateA(
-					value = when (state) {
-						is TestState.StateA -> state.value
-						is TestState.StateB -> state.value
-						is TestState.StateC -> state.value
-						is TestState.NestedState -> state.nestedValue
-					},
-				)
-			}
-			nestedState<TestState.NestedState> {
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.StateB(value = state.nestedValue)
-				}
-				state<TestState.NestedState.NestedStateA>()
-				state<TestState.NestedState.NestedStateB>()
-			}
-			state<TestState.StateA>()
-			state<TestState.StateB>()
-			state<TestState.StateC>()
-		}
-
-		val expected = listOf(
-			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
-			TestState.StateB(value = "I am a value"),
-		)
-
-		val actual = backgroundScope.async {
-			machine.take(expected.count()).toList()
-		}
-
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-
-		assertContentEquals(expected, actual.await())
-	}
-
-	@Test
-	fun `Check parents will handle events if no defined state handles it`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.NestedState.NestedStateA("I am a value"),
-		) {
-			onEvent<TestEvent.MoveForward> { state, _ ->
-				TestState.StateA(
-					value = when (state) {
-						is TestState.StateA -> state.value
-						is TestState.StateB -> state.value
-						is TestState.StateC -> state.value
-						is TestState.NestedState -> state.nestedValue
-					},
-				)
-			}
-			nestedState<TestState.NestedState> {
-				state<TestState.NestedState.NestedStateA>()
-				state<TestState.NestedState.NestedStateB>()
-			}
-			state<TestState.StateA>()
-			state<TestState.StateB>()
-			state<TestState.StateC>()
-		}
-
-		val expected = listOf(
-			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
-			TestState.StateA(value = "I am a value"),
-		)
-
-		val actual = backgroundScope.async {
-			machine.take(expected.count()).toList()
-		}
-
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-
-		assertContentEquals(expected, actual.await())
-	}
-
-	@Test
-	fun `Check we ignore unhandled events`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.NestedState.NestedStateA("I am a value"),
-		) {
-			nestedState<TestState.NestedState> {
-				state<TestState.NestedState.NestedStateA>()
-				state<TestState.NestedState.NestedStateB>()
-			}
-			state<TestState.StateA>()
-			state<TestState.StateB>()
-			state<TestState.StateC>()
-		}
-
-
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-
-		assertEquals(
-			TestState.NestedState.NestedStateA(nestedValue = "I am a value"),
-			machine.value,
-		)
-	}
-
-	@Test
-	fun `Check we can trigger effects and we can trigger multiple`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.Eagerly,
-		) {
-			state<TestState.StateA> {
-				onEvent<TestEvent.Close> { _, _ ->
-					trigger(TestEffect.Close)
-					trigger(TestEffect.Close)
-				}
-			}
-		}
-		val expectedEffects = listOf(TestEffect.Close, TestEffect.Close)
-		val actualEffects = backgroundScope.async { machine.effect.take(expectedEffects.count()).toList() }
-
-		machine.send(TestEvent.Close)
-		advanceUntilIdle()
-
-		assertContentEquals(expectedEffects, actualEffects.await())
-
-		assertEquals(
-			TestState.StateA(value = "I am a value"),
-			machine.value,
-		)
-	}
-
-	@Test
-	fun `Check we can trigger effects and update state`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.Eagerly,
-		) {
-			state<TestState.StateA> {
-				onEvent<TestEvent.Close> { state, _ ->
-					trigger(TestEffect.Close)
-					TestState.StateB(value = state.value)
-				}
-			}
-		}
-
-		machine.send(TestEvent.Close)
-		advanceUntilIdle()
-
-		assertEquals(TestEffect.Close, machine.effect.first())
-
-		assertEquals(
-			TestState.StateB(value = "I am a value"),
-			machine.value,
-		)
-	}
-
-	@Test
-	fun `Check work is cancelled when machine gets inactive after default 5 seconds`() = runTest {
-		var sideEffectJob: Job? = null
-
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.WhileSubscribed(5.seconds),
-		) {
-			state<TestState.StateA> {
-				sideEffect {
-					coroutineScope {
-						sideEffectJob = launch { delay(Long.MAX_VALUE) }
-					}
-				}
-			}
-		}
-
-		advanceUntilIdle()
-		assertNull(sideEffectJob)
-
-		val observeJob = backgroundScope.launch { machine.collect() }
-		advanceTimeBy(1.milliseconds)
-
-		assertTrue { assertNotNull(sideEffectJob).isActive }
-
-		observeJob.cancel()
-		advanceTimeBy(4.seconds)
-
-		// Job should still be active
-		assertTrue { assertNotNull(sideEffectJob).isActive }
-
-		advanceTimeBy(2.seconds)
-
-		// Now job should be cancelled
-		assertTrue { assertNotNull(sideEffectJob).isCancelled }
-	}
-
-	@Test
-	fun `Check state machine picks up at last state after restarting and jobs restart as well`() = runTest {
-		var sideEffectCount = 0
-
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.WhileSubscribed(),
-		) {
-			state<TestState.StateA> {
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.StateB(value = state.value)
-				}
-			}
-			state<TestState.StateB> {
-				sideEffect {
-					sideEffectCount++
-				}
-			}
-		}
-
-		val observeJob = backgroundScope.launch { machine.collect() }
-		machine.send(TestEvent.MoveForward)
-
-		advanceTimeBy(1.milliseconds)
-		assertEquals(1, sideEffectCount)
-		assertEquals(TestState.StateB("I am a value"), machine.value)
-
-		observeJob.cancel()
-		// Check we keep state
-		advanceTimeBy(1.milliseconds)
-		assertEquals(TestState.StateB("I am a value"), machine.value)
-
-		// Restart work
-		backgroundScope.launch { machine.collect() }
-		advanceTimeBy(1.milliseconds)
-
-		// Check we kept the state and launched the side effect again
-		assertEquals(2, sideEffectCount)
-		assertEquals(TestState.StateB("I am a value"), machine.value)
-	}
-
-	@Test
-	fun `Check we suspend events while state machine is inactive`() = runTest {
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.WhileSubscribed(),
-		) {
-			state<TestState.StateA> {
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.StateB(value = state.value)
-				}
-			}
-			state<TestState.StateB> {
-				onEvent<TestEvent.Append> { state, event ->
-					state.copy(value = state.value + event.value)
-				}
-			}
-		}
-
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-
-		// Check we didn't change state yet as collection didn't start
-		assertEquals(TestState.StateA("I am a value"), machine.value)
-		val observeJob = backgroundScope.launch { machine.collect() }
-		advanceTimeBy(1.milliseconds)
-
-		// Check we moved state after collection started
-		assertEquals(TestState.StateB("I am a value"), machine.value)
-
-		observeJob.cancel()
-		// Check we keep state
-		advanceTimeBy(1.milliseconds)
-		assertEquals(TestState.StateB("I am a value"), machine.value)
-
-		// Send a bunch of events
-		machine.send(TestEvent.Append("-"))
-		machine.send(TestEvent.Append("-"))
-		machine.send(TestEvent.Append("-"))
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.Append("-"))
-		advanceTimeBy(1.milliseconds)
-
-		// Make sure nothing happened yet
-		assertEquals(TestState.StateB("I am a value"), machine.value)
-
-		// Restart work
-		backgroundScope.launch { machine.collect() }
-		advanceTimeBy(1.milliseconds)
-
-		// Check we kept the events to update after we started to collect
-		assertEquals(TestState.StateB("I am a value----"), machine.value)
-	}
 
 	@Test
 	fun `Check nothing will really happen if new state is the same as last state`() = runTest {
@@ -476,161 +67,6 @@ class StateMachineTest {
 
 		assertContentEquals(expectedStates, actualStates)
 		assertEquals(1, sideEffectCounter)
-	}
-
-	@Test
-	fun `Check all side effects will run on every state change if no key is given`() = runTest {
-		var machineSideEffectCounter = 0
-		var stateASideEffectCounter = 0
-		var nestedSideEffectCounter = 0
-		var nestedStateASideEffectCounter = 0
-		var nestedStateBSideEffectCounter = 0
-
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.Eagerly,
-		) {
-			sideEffect {
-				machineSideEffectCounter++
-			}
-			state<TestState.StateA> {
-				sideEffect {
-					stateASideEffectCounter++
-				}
-
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.NestedState.NestedStateA(nestedValue = state.value)
-				}
-			}
-			nestedState<TestState.NestedState> {
-				sideEffect {
-					nestedSideEffectCounter++
-				}
-
-				state<TestState.NestedState.NestedStateA> {
-					sideEffect {
-						nestedStateASideEffectCounter++
-					}
-
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
-					}
-				}
-				state<TestState.NestedState.NestedStateB> {
-					sideEffect {
-						nestedStateBSideEffectCounter++
-					}
-				}
-			}
-		}
-
-		val expectedStates = listOf(
-			TestState.StateA("I am a value"),
-			TestState.NestedState.NestedStateA("I am a value"),
-			TestState.NestedState.NestedStateB("I am a value"),
-		)
-
-		val actualStates = backgroundScope.async { machine.take(expectedStates.count()).toList() }
-
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-
-		assertContentEquals(expectedStates, actualStates.await())
-		assertEquals(3, machineSideEffectCounter)
-		assertEquals(1, stateASideEffectCounter)
-		assertEquals(2, nestedSideEffectCounter)
-		assertEquals(1, nestedStateASideEffectCounter)
-		assertEquals(1, nestedStateBSideEffectCounter)
-	}
-
-	@Test
-	fun `Check side effects will not run multiple times if key doesn't change`() = runTest {
-		var machineSideEffectCounter = 0
-		var stateASideEffectCounter = 0
-		var nestedSideEffectCounter = 0
-		var nestedStateASideEffectCounter = 0
-		var nestedStateBSideEffectCounter = 0
-
-		val machine = stateMachine<TestState, TestEffect, TestEvent>(
-			scope = backgroundScope,
-			initialState = TestState.StateA("I am a value"),
-			started = SharingStarted.Eagerly,
-		) {
-			sideEffect(
-				key = { state ->
-					// Do a stupid comparison to just show we can calculate the keys
-					when (state) {
-						is TestState.NestedState -> state.nestedValue
-						is TestState.StateA -> state.value
-						is TestState.StateB -> state.value
-						is TestState.StateC -> state.value
-					}
-				},
-			) {
-				machineSideEffectCounter++
-			}
-			state<TestState.StateA> {
-				sideEffect(key = {}) { // Can simply use Unit
-					stateASideEffectCounter++
-				}
-
-				onEvent<TestEvent.MoveForward> { state, _ ->
-					TestState.NestedState.NestedStateA(nestedValue = state.value)
-				}
-			}
-			nestedState<TestState.NestedState> {
-				sideEffect(key = {}) { // Can simply use Unit to never run again
-					nestedSideEffectCounter++
-				}
-
-				state<TestState.NestedState.NestedStateA> {
-					sideEffect(key = {}) { // Can simply use Unit
-						nestedStateASideEffectCounter++
-					}
-
-					onEvent<TestEvent.MoveForward> { state, _ ->
-						TestState.NestedState.NestedStateB(nestedValue = state.nestedValue)
-					}
-				}
-				state<TestState.NestedState.NestedStateB> {
-					sideEffect(key = { state -> state.nestedValue }) {
-						nestedStateBSideEffectCounter++
-					}
-
-					onEvent<TestEvent.Append> { state, event ->
-						state.copy(nestedValue = state.nestedValue + event.value)
-					}
-				}
-			}
-		}
-
-		val expectedStates = listOf(
-			TestState.StateA("I am a value"),
-			TestState.NestedState.NestedStateA("I am a value"),
-			TestState.NestedState.NestedStateB("I am a value"),
-			TestState.NestedState.NestedStateB("I am a value!!!"),
-		)
-
-		val actualStates = backgroundScope.async { machine.take(expectedStates.count()).toList() }
-
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.MoveForward)
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.Append(""))
-		advanceTimeBy(1.milliseconds)
-		machine.send(TestEvent.Append("!!!"))
-		advanceTimeBy(1.milliseconds)
-
-		assertContentEquals(expectedStates, actualStates.await())
-		assertEquals(2, machineSideEffectCounter)
-		assertEquals(1, stateASideEffectCounter)
-		assertEquals(1, nestedSideEffectCounter)
-		assertEquals(1, nestedStateASideEffectCounter)
-		assertEquals(2, nestedStateBSideEffectCounter)
 	}
 
 	@Test
@@ -699,35 +135,47 @@ class StateMachineTest {
 		assertEquals(TestState.StateB("I am a value"), machine.value)
 	}
 
-	private sealed interface TestState {
+	@Test
+	fun `Check state machine picks up at last state after restarting and jobs restart as well`() = runTest {
+		var sideEffectCount = 0
 
-		data class StateA(val value: String) : TestState
-		data class StateB(val value: String) : TestState
-		data class StateC(val value: String) : TestState
-
-		sealed interface NestedState : TestState {
-
-			val nestedValue: String
-
-			data class NestedStateA(override val nestedValue: String) : NestedState
-			data class NestedStateB(override val nestedValue: String) : NestedState
-
+		val machine = stateMachine<TestState, TestEffect, TestEvent>(
+			scope = backgroundScope,
+			initialState = TestState.StateA("I am a value"),
+			started = SharingStarted.WhileSubscribed(),
+		) {
+			state<TestState.StateA> {
+				onEvent<TestEvent.MoveForward> { state, _ ->
+					TestState.StateB(value = state.value)
+				}
+			}
+			state<TestState.StateB> {
+				sideEffect {
+					sideEffectCount++
+				}
+			}
 		}
 
+		val observeJob = backgroundScope.launch { machine.collect() }
+		machine.send(TestEvent.MoveForward)
+
+		advanceTimeBy(1.milliseconds)
+		assertEquals(1, sideEffectCount)
+		assertEquals(TestState.StateB("I am a value"), machine.value)
+
+		observeJob.cancel()
+		// Check we keep state
+		advanceTimeBy(1.milliseconds)
+		assertEquals(TestState.StateB("I am a value"), machine.value)
+
+		// Restart work
+		backgroundScope.launch { machine.collect() }
+		advanceTimeBy(1.milliseconds)
+
+		// Check we kept the state and launched the side effect again
+		assertEquals(2, sideEffectCount)
+		assertEquals(TestState.StateB("I am a value"), machine.value)
 	}
 
-	private sealed interface TestEffect {
-
-		data object Close : TestEffect
-
-	}
-
-	private sealed interface TestEvent {
-
-		data object MoveForward : TestEvent
-		data class Append(val value: String) : TestEvent
-		data object Close : TestEvent
-
-	}
 
 }

--- a/library/src/commonTest/kotlin/dev/klitsie/statemachine/TestState.kt
+++ b/library/src/commonTest/kotlin/dev/klitsie/statemachine/TestState.kt
@@ -1,0 +1,33 @@
+package dev.klitsie.statemachine
+
+sealed interface TestState {
+
+	data class StateA(val value: String) : TestState
+	data class StateB(val value: String) : TestState
+	data class StateC(val value: String) : TestState
+
+	sealed interface NestedState : TestState {
+
+		val nestedValue: String
+
+		data class NestedStateA(override val nestedValue: String) : NestedState
+		data class NestedStateB(override val nestedValue: String) : NestedState
+
+	}
+
+}
+
+sealed interface TestEffect {
+
+	data object Close : TestEffect
+	data class Count(val count: Int) : TestEffect
+
+}
+
+sealed interface TestEvent {
+
+	data object MoveForward : TestEvent
+	data class Append(val value: String) : TestEvent
+	data object Close : TestEvent
+
+}


### PR DESCRIPTION
…ts method that provides a way to consume effects from the state machine safely

added JavaDoc
Fixed up @StateDsl annotation for effect handler
Restructured unit tests by splitting them up to the specific part of the machine what they test. Fixed namespace
Upped version
Updated readme